### PR TITLE
Adding schema/migration support

### DIFF
--- a/src/Type/JsonDocumentType.php
+++ b/src/Type/JsonDocumentType.php
@@ -136,7 +136,15 @@ final class JsonDocumentType extends InternalParentClass
 
         return $this->getSerializer()->deserialize($value, '', $this->format, $this->deserializationContext);
     }
-
+      
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return sprintf('JSON');
+    }
+    
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
When using doctrine schema tooling, the type used for the JSON column is LONGTEXT. It should be a JSON type column. Maybe this should be configurable somehow.